### PR TITLE
hotfix: Revert to nullish coalescence to empty array when no annotations are present

### DIFF
--- a/src/models/PBOMLDocument.js
+++ b/src/models/PBOMLDocument.js
@@ -201,8 +201,8 @@ export default class PBOMLDocument {
             },
 
             slices: this.slices.map((slice) => slice.toArray()),
-            annotations: this.annotations.map((annotation) =>
-                annotation.toArray(),
+            annotations: this.annotations.map(
+                (annotation) => annotation.toArray() ?? [],
             ),
         };
 


### PR DESCRIPTION
…ons are present