### PR TITLE
test: Add validation and tests for slices and annotations.

### DIFF
--- a/src/models/PBOMLDocument.errors.js
+++ b/src/models/PBOMLDocument.errors.js
@@ -1,9 +1,13 @@
 export const PBOMLDocumentErrors = {
-    annotationsIsNull: "annotations is null.",
-    fileIsEmpty: "File is empty or pboml is missing.",
-    pbomlIsUndefined: "pboml is undefined.",
-    pbomlIsNull: "pboml is null.",
-    versionIsEmptyString: "version is empty string",
-    versionIsNotSupported: "version is not supported",
-    versionIsNull: "version is null",
+    annotationsIsNotArrayOrObject:
+        "The value of key 'annotations' is not an array or an object.",
+    annotationsIsNull: "The value of key 'annotations' is null.",
+    fileIsEmpty: "The YAML file is empty.",
+    pbomlIsUndefined: "The key 'pboml' is undefined.",
+    pbomlIsNull: "The value of key 'pboml' is null.",
+    slicesIsNotArrayOrObject:
+        "The value of key 'slices' is not an array or an object.",
+    versionIsEmptyString: "The value of key 'version' is an empty string.",
+    versionIsNotSupported: "The value of key 'version' is not supported.",
+    versionIsNull: "The value of key 'version' is null.",
 };

--- a/src/models/PBOMLDocument.js
+++ b/src/models/PBOMLDocument.js
@@ -69,53 +69,71 @@ export default class PBOMLDocument {
         this.user_data = mainDocument.document?.user_data;
 
         // slices
+        const slices = mainDocument.slices;
+
+        if (slices === undefined || slices === null) {
+            this.slices = [];
+        } else if (Array.isArray(slices)) {
+            this.slices = slices;
+        } else if (typeof slices === "object") {
+            this.slices = Object.values(slices);
+        } else {
+            throw new Error(PBOMLDocumentErrors.slicesIsNotArrayOrObject);
+        }
+
         let counter = 0;
 
-        this.slices =
-            mainDocument.slices
-                ?.map((element) => {
-                    let slice =
-                        PBOMLDocument.provisionSliceFromPayload(element);
+        this.slices = this.slices
+            .map((element) => {
+                let slice = PBOMLDocument.provisionSliceFromPayload(element);
 
-                    counter++;
+                counter++;
 
-                    if (slice) {
-                        slice.state.sequence = counter;
-                        slice.state.prefix = prefix;
-                        //slice.state.callbacks.move = (s) => this.handleSliceMove(s);
-                        //slice.state.callbacks.delete = (s) => this.handleSliceDelete(s);
+                if (slice) {
+                    slice.state.sequence = counter;
+                    slice.state.prefix = prefix;
+                    //slice.state.callbacks.move = (s) => this.handleSliceMove(s);
+                    //slice.state.callbacks.delete = (s) => this.handleSliceDelete(s);
 
-                        if (counter === 1) {
-                            slice.state.canMoveUp = false;
-                        }
-
-                        if (counter === mainDocument.slices.length) {
-                            slice.state.canMoveDown = false;
-                        }
-
-                        return slice;
+                    if (counter === 1) {
+                        slice.state.canMoveUp = false;
                     }
-                })
-                .filter((n) => n) ?? [];
+
+                    if (counter === mainDocument.slices.length) {
+                        slice.state.canMoveDown = false;
+                    }
+
+                    return slice;
+                }
+            })
+            .filter((n) => n);
 
         // annotations
-        try {
-            this.annotations = mainDocument.annotations
-                .map((element) => {
-                    let annotation = new Annotation(element);
-                    annotation.state.prefix = prefix;
+        const annotations = mainDocument.annotations;
 
-                    return annotation;
-                })
-                .filter((n) => n)
-                .sort((a, b) =>
-                    `${a.id}`.localeCompare(`${b.id}`, undefined, {
-                        numeric: true,
-                    }),
-                );
-        } catch (error) {
+        if (annotations === undefined || annotations === null) {
             this.annotations = [];
+        } else if (Array.isArray(annotations)) {
+            this.annotations = annotations;
+        } else if (typeof annotations === "object") {
+            this.annotations = Object.values(annotations);
+        } else {
+            throw new Error(PBOMLDocumentErrors.annotationsIsNotArrayOrObject);
         }
+
+        this.annotations = this.annotations
+            .map((element) => {
+                let annotation = new Annotation(element);
+                annotation.state.prefix = prefix;
+
+                return annotation;
+            })
+            .filter((n) => n)
+            .sort((a, b) =>
+                `${a.id}`.localeCompare(`${b.id}`, undefined, {
+                    numeric: true,
+                }),
+            );
 
         this.state = {
             prefix,

--- a/tests/models/PBOMLDocument.test.js
+++ b/tests/models/PBOMLDocument.test.js
@@ -9,72 +9,115 @@ import PBOMLDocument from "../../src/models/PBOMLDocument.js";
 import HeadingSlice from "../../src/models/contents/HeadingSlice.js";
 
 // Samples
+import annotationsIsNotArrayOrObject from "../samples/annotationsIsNotArrayOrObject.yaml?raw";
+import annotationsIsNull from "../samples/annotationsIsNull.yaml?raw";
+import annotationsIsObject from "../samples/annotationsIsObject.yaml?raw";
+import annotationsIsUndefined from "../samples/annotationsIsUndefined.yaml?raw";
 import fileIsEmpty from "../samples/fileIsEmpty.yaml?raw";
+import sliceIsHeading from "../samples/sliceIsHeading.yaml?raw";
 import pbomlIsUndefined from "../samples/pbomlIsUndefined.yaml?raw";
 import pbomlIsNull from "../samples/pbomlIsNull.yaml?raw";
+import slicesHasOneSlice from "../samples/slicesHasOneSlice.yaml?raw";
+import slicesHasTwoSlices from "../samples/slicesHasTwoSlices.yaml?raw";
+import slicesIsNotArrayOrObject from "../samples/slicesIsNotArrayOrObject.yaml?raw";
+import slicesIsNull from "../samples/slicesIsNull.yaml?raw";
+import slicesIsObject from "../samples/slicesIsObject.yaml?raw";
+import slicesIsUndefined from "../samples/slicesIsUndefined.yaml?raw";
 import versionIsEmptyString from "../samples/versionIsEmptyString.yaml?raw";
 import versionIsNull from "../samples/versionIsNull.yaml?raw";
 import versionIsNotSupported from "../samples/versionIsNotSupported.yaml?raw";
-import slicesIsNull from "../samples/slicesIsNull.yaml?raw";
-import annotationsIsNull from "../samples/annotationsIsNull.yaml?raw";
-import slicesIsEmpty from "../samples/slicesIsEmpty.yaml?raw";
-import slicesHasOneSlice from "../samples/slicesHasOneSlice.yaml?raw";
-import slicesHasTwoSlices from "../samples/slicesHasTwoSlices.yaml?raw";
-import sliceIsHeading from "../samples/sliceIsHeading.yaml?raw";
 
 // Error Messages
 import { PBOMLDocumentErrors } from "../../src/models/PBOMLDocument.errors.js";
 import { YAMLException } from "js-yaml";
 
 describe("PBOMLDocument", () => {
-    it("throws an error when YAML file is empty", () => {
+    it("throws an error when the YAML file is empty", () => {
         expect(() => PBOMLDocument.initFromYaml(fileIsEmpty)).toThrow(
             PBOMLDocumentErrors.fileIsEmpty,
         );
     });
 
-    it("throws an error when pboml is undefined", () => {
+    it("throws an error when the key 'pboml' is undefined", () => {
         expect(() => PBOMLDocument.initFromYaml(pbomlIsUndefined)).toThrow(
             PBOMLDocumentErrors.pbomlIsUndefined,
         );
     });
 
-    it("throws an error when pboml is null", () => {
+    it("throws an error when the value of key 'pboml' is null", () => {
         expect(() => PBOMLDocument.initFromYaml(pbomlIsNull)).toThrow(
             PBOMLDocumentErrors.pbomlIsNull,
         );
     });
 
-    it("throws an error when version is null", () => {
+    it("throws an error when the value of key 'version' is null", () => {
         expect(() => PBOMLDocument.initFromYaml(versionIsNull)).toThrow(
             PBOMLDocumentErrors.versionIsNull,
         );
     });
 
-    it("throws an error when version is empty string", () => {
+    it("throws an error when the value of key 'version' is an empty string", () => {
         expect(() => PBOMLDocument.initFromYaml(versionIsEmptyString)).toThrow(
             PBOMLDocumentErrors.versionIsEmptyString,
         );
     });
 
-    it("throws an error when version is not supported", () => {
+    it("throws an error when the value of key 'version' is not supported", () => {
         expect(() => PBOMLDocument.initFromYaml(versionIsNotSupported)).toThrow(
             PBOMLDocumentErrors.versionIsNotSupported,
         );
     });
 
-    it("returns empty slices array when slices is null", () => {
+    it("returns an empty array when the key 'slices' is undefined", () => {
+        const document = PBOMLDocument.initFromYaml(slicesIsUndefined);
+
+        expect(document.slices).toBeInstanceOf(Array);
+        expect(document.slices).toHaveLength(0);
+    });
+
+    it("returns an empty array when the value of key 'slices' is null", () => {
         const document = PBOMLDocument.initFromYaml(slicesIsNull);
 
         expect(document.slices).toBeInstanceOf(Array);
         expect(document.slices).toHaveLength(0);
     });
 
-    it("returns empty annotations array when annotations is null", () => {
+    it("returns an array when the value of key 'slices' is an object", () => {
+        const document = PBOMLDocument.initFromYaml(slicesIsObject);
+
+        expect(document.annotations).toBeInstanceOf(Array);
+    });
+
+    it("throws an error when the value of key 'slices' is not an array or an object", () => {
+        expect(() => PBOMLDocument.initFromYaml(slicesIsNotArrayOrObject));
+    });
+
+    it("returns an empty array when the key 'annotations' is undefined", () => {
+        const document = PBOMLDocument.initFromYaml(annotationsIsUndefined);
+
+        expect(document.annotations).toBeInstanceOf(Array);
+        expect(document.annotations).toHaveLength(0);
+    });
+
+    it("returns an empty array when the value of key 'annotations' is null", () => {
         const document = PBOMLDocument.initFromYaml(annotationsIsNull);
 
         expect(document.annotations).toBeInstanceOf(Array);
         expect(document.annotations).toHaveLength(0);
+    });
+
+    it("returns an array when the value of key 'annotations' is an object", () => {
+        const document = PBOMLDocument.initFromYaml(annotationsIsObject);
+
+        expect(document.annotations).toBeInstanceOf(Array);
+    });
+
+    it("throws an error when the value of key 'annotations' is not an array or an object", () => {
+        expect(() =>
+            PBOMLDocument.initFromYaml(annotationsIsNotArrayOrObject).toThrow(
+                PBOMLDocumentErrors.annotationsIsNotArrayOrObject,
+            ),
+        );
     });
 
     it("adds a slice in the correct position to the slices array", () => {

--- a/tests/models/PBOMLDocument.test.js
+++ b/tests/models/PBOMLDocument.test.js
@@ -89,7 +89,9 @@ describe("PBOMLDocument", () => {
     });
 
     it("throws an error when the value of key 'slices' is not an array or an object", () => {
-        expect(() => PBOMLDocument.initFromYaml(slicesIsNotArrayOrObject));
+        expect(() =>
+            PBOMLDocument.initFromYaml(slicesIsNotArrayOrObject),
+        ).toThrow(PBOMLDocumentErrors.slicesIsNotArrayOrObject);
     });
 
     it("returns an empty array when the key 'annotations' is undefined", () => {

--- a/tests/samples/annotationsIsNotArrayOrObject.yaml
+++ b/tests/samples/annotationsIsNotArrayOrObject.yaml
@@ -1,0 +1,4 @@
+pboml:
+    version: 1.0.0
+slices: []
+annotations: String

--- a/tests/samples/annotationsIsObject.yaml
+++ b/tests/samples/annotationsIsObject.yaml
@@ -1,0 +1,22 @@
+pboml:
+    version: 1.0.0
+slices: []
+annotations:
+    "0":
+        id: 1
+        content_type: markdown
+        content:
+            en: Note 1
+            fr: Note 1
+    "1":
+        id: 2
+        content_type: markdown
+        content:
+            en: Note 2
+            fr: Note 2
+    "2":
+        id: 3
+        content_type: markdown
+        content:
+            en: Note 3
+            fr: Note 3

--- a/tests/samples/annotationsIsUndefined.yaml
+++ b/tests/samples/annotationsIsUndefined.yaml
@@ -1,0 +1,3 @@
+pboml:
+    version: 1.0.0
+slices: []

--- a/tests/samples/slicesIsNotArrayOrObject.yaml
+++ b/tests/samples/slicesIsNotArrayOrObject.yaml
@@ -1,0 +1,3 @@
+pboml:
+    version: 1.0.0
+slices: "String"

--- a/tests/samples/slicesIsObject.yaml
+++ b/tests/samples/slicesIsObject.yaml
@@ -1,0 +1,21 @@
+pboml:
+    version: 1.0.0
+slices:
+    "0":
+        id: 1
+        type: markdown
+        content:
+            en: Slice 1
+            fr: Tranche 1
+    "1":
+        id: 2
+        type: markdown
+        content:
+            en: Slice 2
+            fr: Tranche 2
+    "2":
+        id: 3
+        type: markdown
+        content:
+            en: Slice 3
+            fr: Tranche 3

--- a/tests/samples/slicesIsUndefined.yaml
+++ b/tests/samples/slicesIsUndefined.yaml
@@ -1,0 +1,2 @@
+pboml:
+    version: 1.0.0


### PR DESCRIPTION
J'ai modifié la validation des slices et annotations et ajouté les tests en conséquence suite à notre discussion. Les deux suivent la même logique et supportent la conversion d'un objet en array.